### PR TITLE
Independent Module - sonic-buildimage code to support port SI configuration per speed

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -227,3 +227,29 @@ class DeviceDataManager:
             # Currently, only fetching BIOS version is supported
             return ComponentCPLDSN2201.get_component_list()
         return ComponentCPLD.get_component_list()
+
+    @classmethod
+    @utils.read_only_cache()
+    def platform_supports_independent_mode(cls):
+        from sonic_py_common import device_info
+        (_, hwsku_dir) = device_info.get_paths_to_platform_and_hwsku_dirs()
+
+        INDEPENDENT_MODULE_SUPPORT_FIELD = 'SAI_INDEPENDENT_MODULE_MODE'
+        INDEPENDENT_MODULE_SUPPORT_DELIMITER = '='
+        INDEPNENT_MODULE_SUPPORT_TRUE_VALUE = '1'
+        SAI_PROFILE_FILE_NAME = 'sai.profile'
+        sai_profile_path = hwsku_dir + '/' + SAI_PROFILE_FILE_NAME
+
+        try:
+            with open(sai_profile_path, "r", encoding='utf-8') as fd:
+                for line in fd:
+                    if line.startswith(INDEPENDENT_MODULE_SUPPORT_FIELD):
+                        if INDEPENDENT_MODULE_SUPPORT_DELIMITER in line:
+                            split_line = line.split(INDEPENDENT_MODULE_SUPPORT_DELIMITER)
+                            if (len(split_line) > 1):
+                                independent_mode_value = split_line[1].strip()
+                                return True if independent_mode_value == INDEPNENT_MODULE_SUPPORT_TRUE_VALUE else False
+                return False
+
+        except FileNotFoundError:
+            return False

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -160,31 +160,6 @@ limited_eeprom = {
 # Global logger class instance
 logger = Logger()
 
-
-<<<<<<< HEAD
-=======
-# SDK initializing stuff, called from chassis
-def initialize_sdk_handle():
-    rc, sdk_handle = sx_api_open(None)
-    if (rc != SX_STATUS_SUCCESS):
-        logger.log_warning("Failed to open api handle, please check whether SDK is running.")
-        sdk_handle = None
-
-    return sdk_handle
-
-
-def deinitialize_sdk_handle(sdk_handle):
-    if sdk_handle is not None:
-        rc = sx_api_close(sdk_handle)
-        if (rc != SX_STATUS_SUCCESS):
-            logger.log_warning("Failed to close api handle.")
-
-        return rc == SXD_STATUS_SUCCESS
-    else:
-         logger.log_warning("Sdk handle is none")
-         return False
-
-
 def is_independent_module(index):
     db = SonicV2Connector(use_unix_socket_path=False)
     db.connect(db.STATE_DB)
@@ -198,19 +173,6 @@ def is_independent_module(index):
     return result == SW_CONTROL_CONTROL_TYPE
 
 
-class SdkHandleContext(object):
-    def __init__(self):
-        self.sdk_handle = None
-
-    def __enter__(self):
-        self.sdk_handle = initialize_sdk_handle()
-        return self.sdk_handle
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        deinitialize_sdk_handle(self.sdk_handle)
-
-
->>>>>>> 4c84d775b... platform code changes to ignore EEPROM restirctions when dealing with CMIS modules on a platform that support Independent Mode
 class NvidiaSFPCommon(SfpOptoeBase):
     def __init__(self, sfp_index):
         super(NvidiaSFPCommon, self).__init__()

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -122,6 +122,7 @@ class TestChassis:
         chassis._fan_drawer_list = []
         assert chassis.get_num_fan_drawers() == 2
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     def test_sfp(self):
         # Test get_num_sfps, it should not create any SFP objects
         DeviceDataManager.get_sfp_count = mock.MagicMock(return_value=3)
@@ -170,6 +171,7 @@ class TestChassis:
     @mock.patch('sonic_platform.sfp_event.sfp_event.check_sfp_status', MagicMock())
     @mock.patch('sonic_platform.sfp_event.sfp_event.__init__', MagicMock(return_value=None))
     @mock.patch('sonic_platform.sfp_event.sfp_event.initialize', MagicMock())
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', MagicMock(return_value=3))
     def test_change_event(self):
         from sonic_platform.sfp_event import sfp_event
@@ -244,12 +246,14 @@ class TestChassis:
             mock_file_content[file_path] = 0
 
     @mock.patch('sonic_platform.chassis.Chassis._wait_reboot_cause_ready', MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     def test_reboot_cause_timeout(self):
         chassis = Chassis()
         major, minor = chassis.get_reboot_cause()
         assert major == chassis.REBOOT_CAUSE_NON_HARDWARE
         assert minor == ''
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.utils.read_int_from_file')
     @mock.patch('sonic_platform.chassis.time.sleep', mock.MagicMock())
     def test_wait_reboot_cause_ready(self, mock_read_int):

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -122,7 +122,7 @@ class TestChassis:
         chassis._fan_drawer_list = []
         assert chassis.get_num_fan_drawers() == 2
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     def test_sfp(self):
         # Test get_num_sfps, it should not create any SFP objects
         DeviceDataManager.get_sfp_count = mock.MagicMock(return_value=3)
@@ -171,7 +171,7 @@ class TestChassis:
     @mock.patch('sonic_platform.sfp_event.sfp_event.check_sfp_status', MagicMock())
     @mock.patch('sonic_platform.sfp_event.sfp_event.__init__', MagicMock(return_value=None))
     @mock.patch('sonic_platform.sfp_event.sfp_event.initialize', MagicMock())
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', MagicMock(return_value=3))
     def test_change_event(self):
         from sonic_platform.sfp_event import sfp_event
@@ -246,14 +246,14 @@ class TestChassis:
             mock_file_content[file_path] = 0
 
     @mock.patch('sonic_platform.chassis.Chassis._wait_reboot_cause_ready', MagicMock(return_value=False))
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     def test_reboot_cause_timeout(self):
         chassis = Chassis()
         major, minor = chassis.get_reboot_cause()
         assert major == chassis.REBOOT_CAUSE_NON_HARDWARE
         assert minor == ''
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.utils.read_int_from_file')
     @mock.patch('sonic_platform.chassis.time.sleep', mock.MagicMock())
     def test_wait_reboot_cause_ready(self, mock_read_int):

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -44,13 +44,13 @@ class TestModule:
         chassis = ModularChassis()
         assert chassis.get_num_sfps() == 4
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     def test_chassis_get_all_sfps(self):
         utils.read_int_from_file = mock.MagicMock(return_value=1)
         chassis = ModularChassis()
         assert len(chassis.get_all_sfps()) == 4
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_max_port_count', mock.MagicMock(return_value=16))
     def test_chassis_get_sfp(self):
         utils.read_int_from_file = mock.MagicMock(return_value=1)

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -44,11 +44,13 @@ class TestModule:
         chassis = ModularChassis()
         assert chassis.get_num_sfps() == 4
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     def test_chassis_get_all_sfps(self):
         utils.read_int_from_file = mock.MagicMock(return_value=1)
         chassis = ModularChassis()
         assert len(chassis.get_all_sfps()) == 4
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_max_port_count', mock.MagicMock(return_value=16))
     def test_chassis_get_sfp(self):
         utils.read_int_from_file = mock.MagicMock(return_value=1)

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -35,7 +35,7 @@ from sonic_platform.chassis import Chassis
 class TestSfp:
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_count', mock.MagicMock(return_value=8))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_max_port_count')
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     def test_sfp_index(self, mock_max_port):
         sfp = SFP(0)
         assert sfp.is_replaceable()
@@ -57,7 +57,7 @@ class TestSfp:
 
     @mock.patch('sonic_platform.sfp.SFP.read_eeprom', mock.MagicMock(return_value=None))
     @mock.patch('sonic_platform.sfp.SFP._get_module_info')
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.chassis.Chassis.get_num_sfps', mock.MagicMock(return_value=2))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     def test_sfp_get_error_status(self, mock_get_error_code):
@@ -89,7 +89,7 @@ class TestSfp:
 
             assert description == expected_description
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.sfp.SFP._get_page_and_page_offset')
     @mock.patch('sonic_platform.sfp.SFP._is_write_protected')
     def test_sfp_write_eeprom(self, mock_limited_eeprom, mock_get_page):
@@ -124,7 +124,7 @@ class TestSfp:
             handle.write.side_effect = OSError('')
             assert not sfp.write_eeprom(0, 1, bytearray([1]))
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.sfp.SFP._get_page_and_page_offset')
     def test_sfp_read_eeprom(self, mock_get_page):
         sfp = SFP(0)
@@ -146,7 +146,7 @@ class TestSfp:
             handle.read.side_effect = OSError('')
             assert sfp.read_eeprom(0, 1) is None
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.device_data.DeviceDataManager.platform_supports_independent_mode', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.sfp.SFP._get_eeprom_path', mock.MagicMock(return_value = None))
     @mock.patch('sonic_platform.sfp.SFP._get_sfp_type_str')
@@ -163,7 +163,7 @@ class TestSfp:
         mock_get_type_str.return_value = 'invalid'
         assert not sfp._is_write_protected(page=0, page_offset=0, num_bytes=1)
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     def test_get_sfp_type_str(self):
         sfp = SFP(0)
         expect_sfp_types = ['cmis', 'sff8636', 'sff8472']
@@ -179,7 +179,7 @@ class TestSfp:
         os.system('rm -rf {}'.format(mock_eeprom_path))
         assert sfp._get_sfp_type_str('invalid') is None
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('os.path.exists')
     @mock.patch('sonic_platform.sfp.SFP._get_eeprom_path')
     @mock.patch('sonic_platform.sfp.SFP._get_sfp_type_str')
@@ -215,7 +215,7 @@ class TestSfp:
         assert page == '/tmp/1/data'
         assert page_offset is 0
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.sfp.SFP._read_eeprom')
     def test_sfp_get_presence(self, mock_read):
         sfp = SFP(0)
@@ -235,7 +235,7 @@ class TestSfp:
         mock_read_int.return_value = 1
         assert sfp.get_presence()
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.sfp.SFP.get_xcvr_api')
     def test_dummy_apis(self, mock_get_xcvr_api):
         mock_api = mock.MagicMock()
@@ -250,7 +250,7 @@ class TestSfp:
         assert sfp.get_rx_los() is None
         assert sfp.get_tx_fault() is None
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.utils.write_file')
     def test_reset(self, mock_write):
         sfp = SFP(0)
@@ -258,7 +258,7 @@ class TestSfp:
         assert sfp.reset()
         mock_write.assert_called_with('/sys/module/sx_core/asic0/module0/reset', '1')
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_get_lpmode(self, mock_read_int):
         sfp = SFP(0)
@@ -269,7 +269,7 @@ class TestSfp:
         mock_read_int.return_value = 2
         assert not sfp.get_lpmode()
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.utils.write_file')
     @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_set_lpmode(self, mock_read_int, mock_write):
@@ -281,7 +281,7 @@ class TestSfp:
         assert sfp.set_lpmode(True)
         mock_write.assert_called_with('/sys/module/sx_core/asic0/module0/power_mode_policy', '2')
 
-    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock())
     @mock.patch('sonic_platform.sfp.SFP.read_eeprom')
     def test_get_xcvr_api(self, mock_read):
         sfp = SFP(0)

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -35,6 +35,7 @@ from sonic_platform.chassis import Chassis
 class TestSfp:
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_count', mock.MagicMock(return_value=8))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_max_port_count')
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     def test_sfp_index(self, mock_max_port):
         sfp = SFP(0)
         assert sfp.is_replaceable()
@@ -56,6 +57,7 @@ class TestSfp:
 
     @mock.patch('sonic_platform.sfp.SFP.read_eeprom', mock.MagicMock(return_value=None))
     @mock.patch('sonic_platform.sfp.SFP._get_module_info')
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.chassis.Chassis.get_num_sfps', mock.MagicMock(return_value=2))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     def test_sfp_get_error_status(self, mock_get_error_code):
@@ -87,6 +89,7 @@ class TestSfp:
 
             assert description == expected_description
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.sfp.SFP._get_page_and_page_offset')
     @mock.patch('sonic_platform.sfp.SFP._is_write_protected')
     def test_sfp_write_eeprom(self, mock_limited_eeprom, mock_get_page):
@@ -121,6 +124,7 @@ class TestSfp:
             handle.write.side_effect = OSError('')
             assert not sfp.write_eeprom(0, 1, bytearray([1]))
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.sfp.SFP._get_page_and_page_offset')
     def test_sfp_read_eeprom(self, mock_get_page):
         sfp = SFP(0)
@@ -142,6 +146,8 @@ class TestSfp:
             handle.read.side_effect = OSError('')
             assert sfp.read_eeprom(0, 1) is None
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.platform_supports_independent_mode', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.sfp.SFP._get_eeprom_path', mock.MagicMock(return_value = None))
     @mock.patch('sonic_platform.sfp.SFP._get_sfp_type_str')
     def test_is_write_protected(self, mock_get_type_str):
@@ -157,6 +163,7 @@ class TestSfp:
         mock_get_type_str.return_value = 'invalid'
         assert not sfp._is_write_protected(page=0, page_offset=0, num_bytes=1)
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     def test_get_sfp_type_str(self):
         sfp = SFP(0)
         expect_sfp_types = ['cmis', 'sff8636', 'sff8472']
@@ -172,6 +179,7 @@ class TestSfp:
         os.system('rm -rf {}'.format(mock_eeprom_path))
         assert sfp._get_sfp_type_str('invalid') is None
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('os.path.exists')
     @mock.patch('sonic_platform.sfp.SFP._get_eeprom_path')
     @mock.patch('sonic_platform.sfp.SFP._get_sfp_type_str')
@@ -207,6 +215,7 @@ class TestSfp:
         assert page == '/tmp/1/data'
         assert page_offset is 0
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.sfp.SFP._read_eeprom')
     def test_sfp_get_presence(self, mock_read):
         sfp = SFP(0)
@@ -226,6 +235,7 @@ class TestSfp:
         mock_read_int.return_value = 1
         assert sfp.get_presence()
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.sfp.SFP.get_xcvr_api')
     def test_dummy_apis(self, mock_get_xcvr_api):
         mock_api = mock.MagicMock()
@@ -240,6 +250,7 @@ class TestSfp:
         assert sfp.get_rx_los() is None
         assert sfp.get_tx_fault() is None
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.utils.write_file')
     def test_reset(self, mock_write):
         sfp = SFP(0)
@@ -247,6 +258,7 @@ class TestSfp:
         assert sfp.reset()
         mock_write.assert_called_with('/sys/module/sx_core/asic0/module0/reset', '1')
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_get_lpmode(self, mock_read_int):
         sfp = SFP(0)
@@ -257,6 +269,7 @@ class TestSfp:
         mock_read_int.return_value = 2
         assert not sfp.get_lpmode()
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.utils.write_file')
     @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_set_lpmode(self, mock_read_int, mock_write):
@@ -268,6 +281,7 @@ class TestSfp:
         assert sfp.set_lpmode(True)
         mock_write.assert_called_with('/sys/module/sx_core/asic0/module0/power_mode_policy', '2')
 
+    @mock.patch('sonic_platform.sfp.is_independent_module', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.sfp.SFP.read_eeprom')
     def test_get_xcvr_api(self, mock_read):
         sfp = SFP(0)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to enable module configuration by SONiC, it's necessary to ignore the platform code that prevents writing to the EEPROM if the platform supports this functionality and the module needs to be configured by the NOS.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I used the 'TRANSCEIVER_MODULES_MGMT' table in STATE_DB to determine whether the module needs to be configured by the NOS. Additionally, I checked the 'sai.profile' file to verify if the platform supports the required functionality.

#### How to verify it
You can verify this by ensuring that when SONiC attempts to configure an active CMIS module, you do not encounter a 'write limited bytes' exception.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
