### PR TITLE
Independent Module - MDF update for Passive modules

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -501,6 +501,7 @@ class ModulesMgmtTask(threading.Thread):
             return STATE_SW_CONTROL
 
         else:
+            # QSFP-DD, OSFP, QSFP+C, QSFP+, QSFP28 - only these 5 are supported currently as independent module - SW controlled
             if isinstance(xcvr_api, cmis.CmisApi) or isinstance(xcvr_api, sff8636.Sff8636Api):
                 power_cap = self.check_power_cap(port, module_sm_obj)
                 if power_cap is STATE_POWER_LIMIT_ERROR:


### PR DESCRIPTION
#### Why I did it
To extend the support of Independent Module to also include passive modules.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I Updated the Module Detection Flow logic to also label passive modules as Software Control

#### How to verify it
Verify passive modules are labeled as SW_CONTROL using the relevant sysfs, and verify all ports are up and have traffic.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

