### PR TITLE
Module Detection Flow Update for CMIS passive modules and SFF passive and active modules

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -510,7 +510,7 @@ class ModulesMgmtTask(threading.Thread):
         module_fd_freq_support_path = SYSFS_INDEPENDENT_FD_FREQ_SUPPORT.format(port)
         val_int = utils.read_int_from_file(module_fd_freq_support_path)
         if 1 == val_int:
-            if isinstance(xcvr_api, cmis.CmisApi):
+            if is_cmis_api(xcvr_api):
                 # for CMIS modules, read the module maximum supported clock of Management Comm Interface (MCI) from module EEPROM.
                 # from byte 2 bits 3-2:
                 # 00b means module supports up to 400KHz
@@ -518,8 +518,8 @@ class ModulesMgmtTask(threading.Thread):
                 logger.log_debug(f"check_module_type reading mci max frequency for port {port}")
                 read_mci = xcvr_api.xcvr_eeprom.read_raw(CMIS_MCI_EEPROM_OFFSET, 1)
                 logger.log_debug(f"check_module_type read mci max frequency {read_mci} for port {port}")
-                frequency = read_mci & CMIS_MCI_MASK
-            elif isinstance(xcvr_api, sff8636.Sff8636Api) or isinstance(xcvr_api, sff8436.Sff8436Api):
+                frequency = (read_mci & CMIS_MCI_MASK) >> 2
+            elif is_sff_api(xcvr_api):
                 # for SFF modules, frequency is always 400KHz
                 frequency = 0
             logger.log_info(f"check_module_type read mci max frequency bits {frequency} for port {port}")

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -73,6 +73,17 @@ CMDLINE_VAL_TO_LOOK_FOR = 'fastfast'
 
 MAX_EEPROM_ERROR_RESET_RETRIES = 4
 
+POWER_CLASS_1_MAX_POWER = 1.5
+POWER_CLASS_2_MAX_POWER = 2
+POWER_CLASS_3_MAX_POWER = 2.5
+POWER_CLASS_4_MAX_POWER = 3.5
+POWER_CLASS_5_MAX_POWER = 4
+POWER_CLASS_6_MAX_POWER = 4.5
+POWER_CLASS_7_MAX_POWER = 5
+
+CMIS_MCI_EEPROM_OFFSET = 2
+CMIS_MCI_MASK = 0b00001100
+
 
 class ModulesMgmtTask(threading.Thread):
 
@@ -493,19 +504,23 @@ class ModulesMgmtTask(threading.Thread):
         module_fd_freq_support_path = SYSFS_INDEPENDENT_FD_FREQ_SUPPORT.format(port)
         val_int = utils.read_int_from_file(module_fd_freq_support_path)
         if 1 == val_int:
-            # read the module maximum supported clock of Management Comm Interface (MCI) from module EEPROM.
-            # from byte 2 bits 3-2:
-            # 00b means module supports up to 400KHz
-            # 01b means module supports up to 1MHz
-            logger.log_debug(f"check_module_type reading mci max frequency for port {port}")
-            read_mci = xcvr_api.xcvr_eeprom.read_raw(2, 1)
-            logger.log_debug(f"check_module_type read mci max frequency {read_mci} for port {port}")
-            mci_bits = read_mci & 0b00001100
-            logger.log_info(f"check_module_type read mci max frequency bits {mci_bits} for port {port}")
+            if isinstance(xcvr_api, cmis.CmisApi):
+                # for CMIS modules, read the module maximum supported clock of Management Comm Interface (MCI) from module EEPROM.
+                # from byte 2 bits 3-2:
+                # 00b means module supports up to 400KHz
+                # 01b means module supports up to 1MHz
+                logger.log_debug(f"check_module_type reading mci max frequency for port {port}")
+                read_mci = xcvr_api.xcvr_eeprom.read_raw(CMIS_MCI_EEPROM_OFFSET, 1)
+                logger.log_debug(f"check_module_type read mci max frequency {read_mci} for port {port}")
+                frequency_bits = read_mci & CMIS_MCI_MASK
+            elif isinstance(xcvr_api, sff8636.Sff8636Api) or isinstance(xcvr_api, sff8436.Sff8436Api):
+                # for SFF modules, frequency is always 400KHz
+                frequency_bits = 0b00
+            logger.log_info(f"check_module_type read mci max frequency bits {frequency_bits} for port {port}")
             # Then, set it to frequency Sysfs using:
             # echo <val> > /sys/module/sx_core/$asic/$module/frequency //  val: 0 - up to 400KHz, 1 - up to 1MHz
             indep_fd_freq = SYSFS_INDEPENDENT_FD_FREQ.format(port)
-            utils.write_file(indep_fd_freq, mci_bits)
+            utils.write_file(indep_fd_freq, frequency_bits)
 
     def check_module_type(self, port, module_sm_obj, dynamic=False):
         logger.log_info("enter check_module_type port {} module_sm_obj {}".format(port, module_sm_obj))
@@ -525,6 +540,9 @@ class ModulesMgmtTask(threading.Thread):
             logger.log_info("check_module_type checking power cap for {} in check_module_type port {} module_sm_obj {}"
                                .format(xcvr_api, port, module_sm_obj))
             power_cap = self.check_power_cap(port, module_sm_obj)
+            if powercap is STATE_ERROR_HANDLER:
+                module_sm_obj.set_final_state(STATE_ERROR_HANDLER)
+                return STATE_ERROR_HANDLER
             if power_cap is STATE_POWER_LIMIT_ERROR:
                 module_sm_obj.set_final_state(STATE_POWER_LIMIT_ERROR)
                 return STATE_POWER_LIMIT_ERROR
@@ -535,6 +553,9 @@ class ModulesMgmtTask(threading.Thread):
             # QSFP-DD, OSFP, QSFP+C, QSFP+, QSFP28 - only these 5 active form factors are supported currently as independent module - SW controlled
             if self.is_supported_for_software_control(xcvr_api):
                 power_cap = self.check_power_cap(port, module_sm_obj)
+                if powercap is STATE_ERROR_HANDLER:
+                    module_sm_obj.set_final_state(STATE_ERROR_HANDLER)
+                    return STATE_ERROR_HANDLER
                 if power_cap is STATE_POWER_LIMIT_ERROR:
                     module_sm_obj.set_final_state(STATE_POWER_LIMIT_ERROR)
                     return STATE_POWER_LIMIT_ERROR
@@ -544,17 +565,49 @@ class ModulesMgmtTask(threading.Thread):
             else:
                 return STATE_FW_CONTROL
 
+    def get_module_max_power(self, port, xcvr_api, module_sm_obj):
+        if isinstance(xcvr_api, cmis.CmisApi):
+            field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.MAX_POWER_FIELD)
+            powercap_ba = xcvr_api.xcvr_eeprom.reader(field.get_offset(), field.get_size())
+            logger.log_info("check_power_cap got powercap bytearray {} for port {} module_sm_obj {}".format(powercap_ba, port, module_sm_obj))
+            powercap = int.from_bytes(powercap_ba, "big")
+            return powercap
+        elif isinstance(xcvr_api, sff8636.Sff8636Api) or isinstance(xcvr_api, sff8436.Sff8436Api):
+            field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.POWER_CLASS_FIELD)
+            power_class_ba = xcvr_api.xcvr_eeprom.reader(field.get_offset(), field.get_size())
+            power_class_bits = {bit_id: int((power_class_ba[0] >> bit_id) & 0b1) for bit_id in [7, 6, 5, 1, 0]}
+            if (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (0, 0, 0, 0):
+                powercap = POWER_CLASS_1_MAX_POWER
+            elif (power_clשass_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (0, 1, 0, 0):
+                powercap = POWER_CLASS_2_MAX_POWER
+            elif (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (1, 0, 0, 0):
+                powercap = POWER_CLASS_3_MAX_POWER
+            elif (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (1, 1, 0, 0):
+                powercap = POWER_CLASS_4_MAX_POWER
+            elif (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (1, 1, 0, 1):
+                powercap = POWER_CLASS_5_MAX_POWER
+            elif (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (1, 1, 1, 0):
+                powercap = POWER_CLASS_6_MAX_POWER
+            elif (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (1, 1, 1, 1):
+                powercap = POWER_CLASS_7_MAX_POWER
+            else:
+                logger.log_error("Invalid value for power class field: {}".format(power_class_ba))
+                module_sm_obj.set_final_state(STATE_ERROR_HANDLER)
+                return STATE_ERROR_HANDLER
+
+            if power_class_bits[5] == 1:
+                read_power_class_8_byte = xcvr_api.xcvr_eeprom.read_raw(107, 1)
+                powercap = max(read_power_class_8_byte, powercap)
+            return powercap
+
     def check_power_cap(self, port, module_sm_obj, dynamic=False):
         logger.log_info("enter check_power_cap port {} module_sm_obj {}".format(port, module_sm_obj))
         sfp = sfp_module.SFP(port)
         xcvr_api = sfp.get_xcvr_api()
-        if isinstance(xcvr_api, cmis.CmisApi):
-            field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.MAX_POWER_FIELD)
-        elif isinstance(xcvr_api, sff8636.Sff8636Api) or isinstance(xcvr_api, sff8436.Sff8436Api):
-            field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.POWER_CLASS_FIELD)
-        powercap_ba = xcvr_api.xcvr_eeprom.reader(field.get_offset(), field.get_size())
-        logger.log_info("check_power_cap got powercap bytearray {} for port {} module_sm_obj {}".format(powercap_ba, port, module_sm_obj))
-        powercap = int.from_bytes(powercap_ba, "big")
+        powercap = self.get_module_max_power(port, xcvr_api, module_sm_obj)
+        if powercap is STATE_ERROR_HANDLER:
+            module_sm_obj.set_final_state(STATE_ERROR_HANDLER)
+            return STATE_ERROR_HANDLER
         logger.log_info("check_power_cap got powercap {} for port {} module_sm_obj {}".format(powercap, port, module_sm_obj))
         indep_fd_power_limit = self.get_sysfs_ethernet_port_fd(SYSFS_INDEPENDENT_FD_POWER_LIMIT, port)
         cage_power_limit = utils.read_int_from_file(indep_fd_power_limit)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -499,7 +499,7 @@ class ModulesMgmtTask(threading.Thread):
             # 01b means module supports up to 1MHz
             logger.log_debug(f"check_module_type reading mci max frequency for port {port}")
             read_mci = xcvr_api.xcvr_eeprom.read_raw(2, 1)
-            logger.log_info(f"check_module_type read mci max frequency {read_mci} for port {port}")
+            logger.log_debug(f"check_module_type read mci max frequency {read_mci} for port {port}")
             mci_bits = read_mci & 0b00001100
             logger.log_info(f"check_module_type read mci max frequency bits {mci_bits} for port {port}")
             # Then, set it to frequency Sysfs using:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -28,7 +28,7 @@ try:
     from .device_data import DeviceDataManager
     from sonic_platform_base.sonic_xcvr.fields import consts
     from sonic_platform_base.sonic_xcvr.api.public import cmis
-    from sonic_platform_base.sonic_xcvr.api.public import sff8636
+    from sonic_platform_base.sonic_xcvr.api.public import sff8636, sff8436
     from . import sfp as sfp_module
     from . import utils
     from swsscommon.swsscommon import SonicV2Connector
@@ -43,8 +43,8 @@ STATE_HW_PRESENT = "Module is plugged to cage"
 STATE_MODULE_AVAILABLE = "Module hw present and power is good"
 STATE_POWERED = "Module power is already loaded"
 STATE_NOT_POWERED = "Module power is not loaded"
-STATE_FW_CONTROL = "The module is not CMIS and FW needs to handle"
-STATE_SW_CONTROL = "The module is CMIS and SW needs to handle"
+STATE_FW_CONTROL = "The module is not CMIS nor SFF and FW needs to handle"
+STATE_SW_CONTROL = "The module is CMIS or SFF and SW needs to handle"
 STATE_ERROR_HANDLER = "An error occurred - read/write error, power limit or power cap."
 STATE_POWER_LIMIT_ERROR = "The cage has not enough power for the plugged module"
 STATE_SYSFS_ERROR = "An error occurred while writing/reading SySFS."
@@ -485,6 +485,9 @@ class ModulesMgmtTask(threading.Thread):
                 return STATE_HW_NOT_PRESENT
         return STATE_NOT_POWERED
 
+    def is_supported_for_software_control(self, xcvr_api):
+        return isinstance(xcvr_api, cmis.CmisApi) or isinstance(xcvr_api, sff8636.Sff8636Api) or isinstance(xcvr_api, sff8436.Sff8436Api)
+
     def update_frequency(self, port, xcvr_api):
         # first read the frequency support - if it's 1 then continue, if it's 0 no need to do anything
         module_fd_freq_support_path = SYSFS_INDEPENDENT_FD_FREQ_SUPPORT.format(port)
@@ -494,7 +497,7 @@ class ModulesMgmtTask(threading.Thread):
             # from byte 2 bits 3-2:
             # 00b means module supports up to 400KHz
             # 01b means module supports up to 1MHz
-            logger.log_info(f"check_module_type reading mci max frequency for port {port}")
+            logger.log_debug(f"check_module_type reading mci max frequency for port {port}")
             read_mci = xcvr_api.xcvr_eeprom.read_raw(2, 1)
             logger.log_info(f"check_module_type read mci max frequency {read_mci} for port {port}")
             mci_bits = read_mci & 0b00001100
@@ -517,6 +520,8 @@ class ModulesMgmtTask(threading.Thread):
             return STATE_FW_CONTROL
 
         if xcvr_api.is_flat_memory():
+            if not self.is_supported_for_software_control(xcvr_api):
+                return STATE_FW_CONTROL
             logger.log_info("check_module_type checking power cap for {} in check_module_type port {} module_sm_obj {}"
                                .format(xcvr_api, port, module_sm_obj))
             power_cap = self.check_power_cap(port, module_sm_obj)
@@ -526,10 +531,9 @@ class ModulesMgmtTask(threading.Thread):
             self.update_frequency(port, xcvr_api)
             logger.log_info("check_module_type port {} setting STATE_SW_CONTROL module ID {} due to flat_mem device".format(xcvr_api, port))
             return STATE_SW_CONTROL
-
         else:
-            # QSFP-DD, OSFP, QSFP+C, QSFP+, QSFP28 - only these 5 active SFF's are supported currently as independent module - SW controlled
-            if isinstance(xcvr_api, cmis.CmisApi) or isinstance(xcvr_api, sff8636.Sff8636Api):
+            # QSFP-DD, OSFP, QSFP+C, QSFP+, QSFP28 - only these 5 active form factors are supported currently as independent module - SW controlled
+            if self.is_supported_for_software_control(xcvr_api):
                 power_cap = self.check_power_cap(port, module_sm_obj)
                 if power_cap is STATE_POWER_LIMIT_ERROR:
                     module_sm_obj.set_final_state(STATE_POWER_LIMIT_ERROR)
@@ -546,7 +550,7 @@ class ModulesMgmtTask(threading.Thread):
         xcvr_api = sfp.get_xcvr_api()
         if isinstance(xcvr_api, cmis.CmisApi):
             field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.MAX_POWER_FIELD)
-        elif isinstance(xcvr_api, sff8636.Sff8636Api):
+        elif isinstance(xcvr_api, sff8636.Sff8636Api) or isinstance(xcvr_api, sff8436.Sff8436Api):
             field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.POWER_CLASS_FIELD)
         powercap_ba = xcvr_api.xcvr_eeprom.reader(field.get_offset(), field.get_size())
         logger.log_info("check_power_cap got powercap bytearray {} for port {} module_sm_obj {}".format(powercap_ba, port, module_sm_obj))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -606,7 +606,7 @@ class ModulesMgmtTask(threading.Thread):
             if power_class_bits[5] == 1:
                 read_power_class_8_byte = xcvr_api.xcvr_eeprom.read_raw(107, 1)
                 powercap = max(read_power_class_8_byte, powercap)
-            return powercap
+            return powercap * 4 # Multiplying this value by 4 will convert it to units of 0.25W, instead of 1W, allowing for meaningful comparisons later in this flow
 
     def check_power_cap(self, port, module_sm_obj, dynamic=False):
         logger.log_info("enter check_power_cap port {} module_sm_obj {}".format(port, module_sm_obj))
@@ -620,7 +620,7 @@ class ModulesMgmtTask(threading.Thread):
         indep_fd_power_limit = self.get_sysfs_ethernet_port_fd(SYSFS_INDEPENDENT_FD_POWER_LIMIT, port)
         cage_power_limit = utils.read_int_from_file(indep_fd_power_limit)
         logger.log_info("check_power_cap got cage_power_limit {} for port {} module_sm_obj {}".format(cage_power_limit, port, module_sm_obj))
-        if powercap > int(cage_power_limit) * 4:  # Multiplying the sysfs value (0.25 Watt units) by 4 aligns it with the EEPROM max power value (1 Watt units), ensuring both are in the same unit for a meaningful comparison
+        if powercap > int(cage_power_limit):
             logger.log_info("check_power_cap powercap {} != cage_power_limit {} for port {} module_sm_obj {}".format(powercap, cage_power_limit, port, module_sm_obj))
             module_sm_obj.set_final_state(STATE_POWER_LIMIT_ERROR)
             return STATE_POWER_LIMIT_ERROR

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -71,8 +71,6 @@ PROC_CMDLINE = "/proc/cmdline"
 CMDLINE_STR_TO_LOOK_FOR = 'SONIC_BOOT_TYPE='
 CMDLINE_VAL_TO_LOOK_FOR = 'fastfast'
 
-STATE_DB_TABLE_NAME_PREFIX = 'TRANSCEIVER_MODULES_MGMT|{}'
-
 MAX_EEPROM_ERROR_RESET_RETRIES = 4
 
 
@@ -97,7 +95,7 @@ class ModulesMgmtTask(threading.Thread):
         self.fds_mapping_to_obj = {}
         self.port_to_fds = {}
         self.fds_events_count_dict = {}
-        self.delete_ports_from_state_db_dict = {}
+        self.delete_ports_and_reset_states_dict = {}
         self.setName("ModulesMgmtTask")
         self.register_hw_present_fds = []
         self.is_warm_reboot = False
@@ -263,7 +261,7 @@ class ModulesMgmtTask(threading.Thread):
                         self.modules_lock_list[port_num].release()
 
             if is_final_state_module:
-                self.add_ports_state_to_state_db()
+                self.map_ports_final_state()
                 self.delete_ports_from_dict()
                 self.send_changes_to_shared_queue()
                 self.register_presece_closed_ports(False, self.register_hw_present_fds)
@@ -324,16 +322,15 @@ class ModulesMgmtTask(threading.Thread):
                         self.deregister_fd_from_polling(module_obj.port_num)
                         # put again module obj in sfp_port_dict so next loop will work on it
                         self.sfp_port_dict[module_obj.port_num] = module_obj
-                        self.delete_ports_from_state_db_dict[module_obj.port_num] = val
+                        self.delete_ports_and_reset_states_dict[module_obj.port_num] = val
                 except Exception as e:
                     logger.log_error("dynamic detection exception on read presence {} for port {} fd name {} traceback:\n{}"
                                     .format(e, module_obj.port_num, module_fd.name, traceback.format_exc()))
-            for port, val in self.delete_ports_from_state_db_dict.items():
+            for port, val in self.delete_ports_and_reset_states_dict.items():
                 logger.log_info(f"dynamic detection resetting all states for port {port} close_presence_ports {val}")
                 module_obj = self.sfp_port_dict[port]
                 module_obj.reset_all_states(close_presence_ports=val)
-            self.delete_ports_state_from_state_db(self.delete_ports_from_state_db_dict.keys())
-            self.delete_ports_from_state_db_dict = {}
+            self.delete_ports_and_reset_states_dict = {}
             for port_num, module_sm_obj in self.sfp_port_dict.items():
                 curr_state = module_sm_obj.get_current_state()
                 logger.log_info(f'dynamic detection STATE_LOG {port_num}: curr_state is {curr_state}')
@@ -376,7 +373,7 @@ class ModulesMgmtTask(threading.Thread):
                         self.modules_lock_list[port_num].release()
 
             if is_final_state_module:
-                self.add_ports_state_to_state_db(dynamic=True)
+                self.map_ports_final_state(dynamic=True)
                 self.delete_ports_from_dict(dynamic=True)
                 self.send_changes_to_shared_queue(dynamic=True)
                 self.register_presece_closed_ports(True, self.register_hw_present_fds)
@@ -662,59 +659,21 @@ class ModulesMgmtTask(threading.Thread):
         self.waiting_modules_list.add(module_sm_obj.port_num)
         logger.log_info("add_port_to_wait_reset waiting_list after adding: {}".format(self.waiting_modules_list))
 
-    def add_ports_state_to_state_db(self, dynamic=False):
-        state_db = None
+    def map_ports_final_state(self, dynamic=False):
         detection_method = 'dynamic' if dynamic else 'static'
-        logger.log_info(f"{detection_method} detection enter add_ports_state_to_state_db")
+        logger.log_info(f"{detection_method} detection enter map_ports_final_state")
         for port, module_obj in self.sfp_port_dict.items():
             final_state = module_obj.get_final_state()
             if final_state:
                 # add port to delete list that we will iterate on later and delete the ports from sfp_port_dict
                 self.sfp_delete_list_from_port_dict.append(port)
                 if final_state in [STATE_HW_NOT_PRESENT, STATE_POWER_LIMIT_ERROR, STATE_ERROR_HANDLER]:
-                    ctrl_type_db_value = '0'
+                    port_status = '0'
                     logger.log_info(f"{detection_method} detection adding port {port} to register_hw_present_fds")
                     self.register_hw_present_fds.append(module_obj)
                 else:
-                    ctrl_type_db_value = '1'
-                self.sfp_changes_dict[str(module_obj.port_num + 1)] = ctrl_type_db_value
-                if final_state in [STATE_SW_CONTROL, STATE_FW_CONTROL]:
-                    namespaces = multi_asic.get_front_end_namespaces()
-                    for namespace in namespaces:
-                        logger.log_info(f"{detection_method} detection getting state_db for port {port} namespace {namespace}")
-                        state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
-                        logger.log_info(f"{detection_method} detection getting state_db for port {port} namespace {namespace}")
-                        logger.log_info(f"{detection_method} detection got state_db for port {port} namespace {namespace}")
-                        if state_db is not None:
-                            logger.log_info(
-                                f"{detection_method} detection connecting to state_db for port {port} namespace {namespace}")
-                            state_db.connect(state_db.STATE_DB)
-                            if final_state in [STATE_FW_CONTROL]:
-                                control_type = 'FW_CONTROL'
-                            elif final_state in [STATE_SW_CONTROL]:
-                                control_type = 'SW_CONTROL'
-                            table_name = STATE_DB_TABLE_NAME_PREFIX.format(port)
-                            logger.log_info(f"{detection_method} detection setting state_db table {table_name} for port {port}"
-                                               f" namespace {namespace} control_type {control_type}")
-                            state_db.set(state_db.STATE_DB, table_name, "control_type", control_type)
-
-    def delete_ports_state_from_state_db(self, ports, dynamic=True):
-        state_db = None
-        detection_method = 'dynamic' if dynamic else 'static'
-        for port in ports:
-            namespaces = multi_asic.get_front_end_namespaces()
-            for namespace in namespaces:
-                logger.log_info(f"{detection_method} detection getting state_db for port {port} namespace {namespace}")
-                state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
-                logger.log_info(f"{detection_method} detection got state_db for port {port} namespace {namespace}")
-                if state_db is not None:
-                    logger.log_info(
-                        f"{detection_method} detection connecting to state_db for port {port} namespace {namespace}")
-                    state_db.connect(state_db.STATE_DB)
-                    table_name = STATE_DB_TABLE_NAME_PREFIX.format(port)
-                    logger.log_info(f"{detection_method} detection deleting state_db table {table_name} "
-                                       f"for port {port} namespace {namespace}")
-                    state_db.delete(state_db.STATE_DB, table_name)
+                    port_status = '1'
+                self.sfp_changes_dict[str(module_obj.port_num + 1)] = port_status
 
     def delete_ports_from_dict(self, dynamic=False):
         detection_method = 'dynamic' if dynamic else 'static'
@@ -820,4 +779,5 @@ class ModuleStateMachine(object):
             self.module_fd.close()
         if self.module_power_good_fd:
             self.module_power_good_fd.close()
+
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -28,6 +28,7 @@ try:
     from .device_data import DeviceDataManager
     from sonic_platform_base.sonic_xcvr.fields import consts
     from sonic_platform_base.sonic_xcvr.api.public import cmis
+    from sonic_platform_base.sonic_xcvr.api.public import sff8636
     from . import sfp as sfp_module
     from . import utils
     from swsscommon.swsscommon import SonicV2Connector
@@ -70,6 +71,8 @@ PROC_CMDLINE = "/proc/cmdline"
 CMDLINE_STR_TO_LOOK_FOR = 'SONIC_BOOT_TYPE='
 CMDLINE_VAL_TO_LOOK_FOR = 'fastfast'
 
+STATE_DB_TABLE_NAME_PREFIX = 'TRANSCEIVER_MODULES_MGMT|{}'
+
 MAX_EEPROM_ERROR_RESET_RETRIES = 4
 
 
@@ -94,7 +97,7 @@ class ModulesMgmtTask(threading.Thread):
         self.fds_mapping_to_obj = {}
         self.port_to_fds = {}
         self.fds_events_count_dict = {}
-        self.delete_ports_and_reset_states_dict = {}
+        self.delete_ports_from_state_db_dict = {}
         self.setName("ModulesMgmtTask")
         self.register_hw_present_fds = []
         self.is_warm_reboot = False
@@ -260,7 +263,7 @@ class ModulesMgmtTask(threading.Thread):
                         self.modules_lock_list[port_num].release()
 
             if is_final_state_module:
-                self.map_ports_final_state()
+                self.add_ports_state_to_state_db()
                 self.delete_ports_from_dict()
                 self.send_changes_to_shared_queue()
                 self.register_presece_closed_ports(False, self.register_hw_present_fds)
@@ -321,15 +324,16 @@ class ModulesMgmtTask(threading.Thread):
                         self.deregister_fd_from_polling(module_obj.port_num)
                         # put again module obj in sfp_port_dict so next loop will work on it
                         self.sfp_port_dict[module_obj.port_num] = module_obj
-                        self.delete_ports_and_reset_states_dict[module_obj.port_num] = val
+                        self.delete_ports_from_state_db_dict[module_obj.port_num] = val
                 except Exception as e:
                     logger.log_error("dynamic detection exception on read presence {} for port {} fd name {} traceback:\n{}"
                                     .format(e, module_obj.port_num, module_fd.name, traceback.format_exc()))
-            for port, val in self.delete_ports_and_reset_states_dict.items():
+            for port, val in self.delete_ports_from_state_db_dict.items():
                 logger.log_info(f"dynamic detection resetting all states for port {port} close_presence_ports {val}")
                 module_obj = self.sfp_port_dict[port]
                 module_obj.reset_all_states(close_presence_ports=val)
-            self.delete_ports_and_reset_states_dict = {}
+            self.delete_ports_state_from_state_db(self.delete_ports_from_state_db_dict.keys())
+            self.delete_ports_from_state_db_dict = {}
             for port_num, module_sm_obj in self.sfp_port_dict.items():
                 curr_state = module_sm_obj.get_current_state()
                 logger.log_info(f'dynamic detection STATE_LOG {port_num}: curr_state is {curr_state}')
@@ -372,7 +376,7 @@ class ModulesMgmtTask(threading.Thread):
                         self.modules_lock_list[port_num].release()
 
             if is_final_state_module:
-                self.map_ports_final_state(dynamic=True)
+                self.add_ports_state_to_state_db(dynamic=True)
                 self.delete_ports_from_dict(dynamic=True)
                 self.send_changes_to_shared_queue(dynamic=True)
                 self.register_presece_closed_ports(True, self.register_hw_present_fds)
@@ -484,6 +488,25 @@ class ModulesMgmtTask(threading.Thread):
                 return STATE_HW_NOT_PRESENT
         return STATE_NOT_POWERED
 
+    def update_frequency(self, port, xcvr_api):
+        # first read the frequency support - if it's 1 then continue, if it's 0 no need to do anything
+        module_fd_freq_support_path = SYSFS_INDEPENDENT_FD_FREQ_SUPPORT.format(port)
+        val_int = utils.read_int_from_file(module_fd_freq_support_path)
+        if 1 == val_int:
+            # read the module maximum supported clock of Management Comm Interface (MCI) from module EEPROM.
+            # from byte 2 bits 3-2:
+            # 00b means module supports up to 400KHz
+            # 01b means module supports up to 1MHz
+            logger.log_info(f"check_module_type reading mci max frequency for port {port}")
+            read_mci = xcvr_api.xcvr_eeprom.read_raw(2, 1)
+            logger.log_info(f"check_module_type read mci max frequency {read_mci} for port {port}")
+            mci_bits = read_mci & 0b00001100
+            logger.log_info(f"check_module_type read mci max frequency bits {mci_bits} for port {port}")
+            # Then, set it to frequency Sysfs using:
+            # echo <val> > /sys/module/sx_core/$asic/$module/frequency //  val: 0 - up to 400KHz, 1 - up to 1MHz
+            indep_fd_freq = SYSFS_INDEPENDENT_FD_FREQ.format(port)
+            utils.write_file(indep_fd_freq, mci_bits)
+
     def check_module_type(self, port, module_sm_obj, dynamic=False):
         logger.log_info("enter check_module_type port {} module_sm_obj {}".format(port, module_sm_obj))
         sfp = sfp_module.SFP(port)
@@ -495,47 +518,38 @@ class ModulesMgmtTask(threading.Thread):
             logger.log_info("check_module_type setting as FW control as xcvr_api is empty for port {} module_sm_obj {}"
                             .format(port, module_sm_obj))
             return STATE_FW_CONTROL
-        # QSFP-DD ID is 24, OSFP ID is 25 - only these 2 are supported currently as independent module - SW controlled
-        if not isinstance(xcvr_api, cmis.CmisApi):
-            logger.log_info("check_module_type setting STATE_FW_CONTROL for {} in check_module_type port {} module_sm_obj {}"
-                            .format(xcvr_api, port, module_sm_obj))
-            return STATE_FW_CONTROL
-        else:
-            if xcvr_api.is_flat_memory():
-                logger.log_info("check_module_type port {} setting STATE_FW_CONTROL module ID {} due to flat_mem device"
-                              .format(xcvr_api, port))
-                return STATE_FW_CONTROL
+
+        if xcvr_api.is_flat_memory():
             logger.log_info("check_module_type checking power cap for {} in check_module_type port {} module_sm_obj {}"
                                .format(xcvr_api, port, module_sm_obj))
             power_cap = self.check_power_cap(port, module_sm_obj)
             if power_cap is STATE_POWER_LIMIT_ERROR:
                 module_sm_obj.set_final_state(STATE_POWER_LIMIT_ERROR)
                 return STATE_POWER_LIMIT_ERROR
-            else:
-                # first read the frequency support - if it's 1 then continue, if it's 0 no need to do anything
-                module_fd_freq_support_path = SYSFS_INDEPENDENT_FD_FREQ_SUPPORT.format(port)
-                val_int = utils.read_int_from_file(module_fd_freq_support_path)
-                if 1 == val_int:
-                    # read the module maximum supported clock of Management Comm Interface (MCI) from module EEPROM.
-                    # from byte 2 bits 3-2:
-                    # 00b means module supports up to 400KHz
-                    # 01b means module supports up to 1MHz
-                    logger.log_info(f"check_module_type reading mci max frequency for port {port}")
-                    read_mci = xcvr_api.xcvr_eeprom.read_raw(2, 1)
-                    logger.log_info(f"check_module_type read mci max frequency {read_mci} for port {port}")
-                    mci_bits = read_mci & 0b00001100
-                    logger.log_info(f"check_module_type read mci max frequency bits {mci_bits} for port {port}")
-                    # Then, set it to frequency Sysfs using:
-                    # echo <val> > /sys/module/sx_core/$asic/$module/frequency //  val: 0 - up to 400KHz, 1 - up to 1MHz
-                    indep_fd_freq = SYSFS_INDEPENDENT_FD_FREQ.format(port)
-                    utils.write_file(indep_fd_freq, mci_bits)
+            self.update_frequency(port, xcvr_api)
+            logger.log_info("check_module_type port {} setting STATE_SW_CONTROL module ID {} due to flat_mem device".format(xcvr_api, port))
+            return STATE_SW_CONTROL
+
+        else:
+            if isinstance(xcvr_api, cmis.CmisApi) or isinstance(xcvr_api, sff8636.Sff8636Api):
+                power_cap = self.check_power_cap(port, module_sm_obj)
+                if power_cap is STATE_POWER_LIMIT_ERROR:
+                    module_sm_obj.set_final_state(STATE_POWER_LIMIT_ERROR)
+                    return STATE_POWER_LIMIT_ERROR
+                self.update_frequency(port, xcvr_api)
+                logger.log_info("check_module_type port {} setting STATE_SW_CONTROL module ID {} due to supported page_mem device".format(xcvr_api, port))
                 return STATE_SW_CONTROL
+            else:
+                return STATE_FW_CONTROL
 
     def check_power_cap(self, port, module_sm_obj, dynamic=False):
         logger.log_info("enter check_power_cap port {} module_sm_obj {}".format(port, module_sm_obj))
         sfp = sfp_module.SFP(port)
         xcvr_api = sfp.get_xcvr_api()
-        field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.MAX_POWER_FIELD)
+        if isinstance(xcvr_api, cmis.CmisApi):
+            field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.MAX_POWER_FIELD)
+        elif isinstance(xcvr_api, sff8636.Sff8636Api):
+            field = xcvr_api.xcvr_eeprom.mem_map.get_field(consts.POWER_CLASS_FIELD)
         powercap_ba = xcvr_api.xcvr_eeprom.reader(field.get_offset(), field.get_size())
         logger.log_info("check_power_cap got powercap bytearray {} for port {} module_sm_obj {}".format(powercap_ba, port, module_sm_obj))
         powercap = int.from_bytes(powercap_ba, "big")
@@ -647,21 +661,59 @@ class ModulesMgmtTask(threading.Thread):
         self.waiting_modules_list.add(module_sm_obj.port_num)
         logger.log_info("add_port_to_wait_reset waiting_list after adding: {}".format(self.waiting_modules_list))
 
-    def map_ports_final_state(self, dynamic=False):
+    def add_ports_state_to_state_db(self, dynamic=False):
+        state_db = None
         detection_method = 'dynamic' if dynamic else 'static'
-        logger.log_info(f"{detection_method} detection enter map_ports_final_state")
+        logger.log_info(f"{detection_method} detection enter add_ports_state_to_state_db")
         for port, module_obj in self.sfp_port_dict.items():
             final_state = module_obj.get_final_state()
             if final_state:
                 # add port to delete list that we will iterate on later and delete the ports from sfp_port_dict
                 self.sfp_delete_list_from_port_dict.append(port)
                 if final_state in [STATE_HW_NOT_PRESENT, STATE_POWER_LIMIT_ERROR, STATE_ERROR_HANDLER]:
-                    port_status = '0'
+                    ctrl_type_db_value = '0'
                     logger.log_info(f"{detection_method} detection adding port {port} to register_hw_present_fds")
                     self.register_hw_present_fds.append(module_obj)
                 else:
-                    port_status = '1'
-                self.sfp_changes_dict[str(module_obj.port_num + 1)] = port_status
+                    ctrl_type_db_value = '1'
+                self.sfp_changes_dict[str(module_obj.port_num + 1)] = ctrl_type_db_value
+                if final_state in [STATE_SW_CONTROL, STATE_FW_CONTROL]:
+                    namespaces = multi_asic.get_front_end_namespaces()
+                    for namespace in namespaces:
+                        logger.log_info(f"{detection_method} detection getting state_db for port {port} namespace {namespace}")
+                        state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+                        logger.log_info(f"{detection_method} detection getting state_db for port {port} namespace {namespace}")
+                        logger.log_info(f"{detection_method} detection got state_db for port {port} namespace {namespace}")
+                        if state_db is not None:
+                            logger.log_info(
+                                f"{detection_method} detection connecting to state_db for port {port} namespace {namespace}")
+                            state_db.connect(state_db.STATE_DB)
+                            if final_state in [STATE_FW_CONTROL]:
+                                control_type = 'FW_CONTROL'
+                            elif final_state in [STATE_SW_CONTROL]:
+                                control_type = 'SW_CONTROL'
+                            table_name = STATE_DB_TABLE_NAME_PREFIX.format(port)
+                            logger.log_info(f"{detection_method} detection setting state_db table {table_name} for port {port}"
+                                               f" namespace {namespace} control_type {control_type}")
+                            state_db.set(state_db.STATE_DB, table_name, "control_type", control_type)
+
+    def delete_ports_state_from_state_db(self, ports, dynamic=True):
+        state_db = None
+        detection_method = 'dynamic' if dynamic else 'static'
+        for port in ports:
+            namespaces = multi_asic.get_front_end_namespaces()
+            for namespace in namespaces:
+                logger.log_info(f"{detection_method} detection getting state_db for port {port} namespace {namespace}")
+                state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+                logger.log_info(f"{detection_method} detection got state_db for port {port} namespace {namespace}")
+                if state_db is not None:
+                    logger.log_info(
+                        f"{detection_method} detection connecting to state_db for port {port} namespace {namespace}")
+                    state_db.connect(state_db.STATE_DB)
+                    table_name = STATE_DB_TABLE_NAME_PREFIX.format(port)
+                    logger.log_info(f"{detection_method} detection deleting state_db table {table_name} "
+                                       f"for port {port} namespace {namespace}")
+                    state_db.delete(state_db.STATE_DB, table_name)
 
     def delete_ports_from_dict(self, dynamic=False):
         detection_method = 'dynamic' if dynamic else 'static'
@@ -767,3 +819,4 @@ class ModuleStateMachine(object):
             self.module_fd.close()
         if self.module_power_good_fd:
             self.module_power_good_fd.close()
+

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -531,13 +531,14 @@ class ModulesMgmtTask(threading.Thread):
             return STATE_SW_CONTROL
 
         else:
+            # QSFP-DD, OSFP, QSFP+C, QSFP+, QSFP28 - only these 5 active SFF's are supported currently as independent module - SW controlled
             if isinstance(xcvr_api, cmis.CmisApi) or isinstance(xcvr_api, sff8636.Sff8636Api):
                 power_cap = self.check_power_cap(port, module_sm_obj)
                 if power_cap is STATE_POWER_LIMIT_ERROR:
                     module_sm_obj.set_final_state(STATE_POWER_LIMIT_ERROR)
                     return STATE_POWER_LIMIT_ERROR
                 self.update_frequency(port, xcvr_api)
-                logger.log_info("check_module_type port {} setting STATE_SW_CONTROL module ID {} due to supported page_mem device".format(xcvr_api, port))
+                logger.log_info("check_module_type port {} setting STATE_SW_CONTROL module ID {} due to supported paged_mem device".format(xcvr_api, port))
                 return STATE_SW_CONTROL
             else:
                 return STATE_FW_CONTROL

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -586,7 +586,7 @@ class ModulesMgmtTask(threading.Thread):
             power_class_bits = {bit_id: int((power_class_ba[0] >> bit_id) & 0b1) for bit_id in [7, 6, 5, 1, 0]}
             if (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (0, 0, 0, 0):
                 powercap = POWER_CLASS_1_MAX_POWER
-            elif (power_clשass_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (0, 1, 0, 0):
+            elif (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (0, 1, 0, 0):
                 powercap = POWER_CLASS_2_MAX_POWER
             elif (power_class_bits[7], power_class_bits[6], power_class_bits[1], power_class_bits[0]) == (1, 0, 0, 0):
                 powercap = POWER_CLASS_3_MAX_POWER

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -780,4 +780,3 @@ class ModuleStateMachine(object):
         if self.module_power_good_fd:
             self.module_power_good_fd.close()
 
-


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Only relevant for Mellanox platforms.

#### Why I did it
To extend the current host CMIS management support for the following form-factors: QSFP-DD, OSFP, QSFP+C, QSFP+, QSFP28. Only these module types should be tagged as SW_CONTROL. All other modules will be tagged as FW_CONTROL.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated the Module Detection Flow algorithm to tag the relevant module types to SW_CONTROL as well.

#### How to verify it
Once the system is up, make sure that the relevant modules are successfully tagged as SW_CONTROL and all others tagged as FW_CONTROL.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

