### PR TITLE
[Mellanox] Validate Module Presence Using Sysfs Before Accessing EEPROM in Thermal Control Daemon

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1947,4 +1947,3 @@ class RJ45Port(NvidiaSFPCommon):
         """
         status = super().get_module_status()
         return SFP_STATUS_REMOVED if status == SFP_STATUS_UNKNOWN else status
-

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1064,8 +1064,6 @@ class SFP(NvidiaSFPCommon):
             0.0 if module temperature is not supported or module is under initialization
             other float value if module temperature is available
         """
-        if not self.get_presence():
-            return None
         try:
             if not self.is_sw_control():
                 temp_file = f'/sys/module/sx_core/asic0/module{self.sdk_index}/temperature/input'
@@ -1090,8 +1088,6 @@ class SFP(NvidiaSFPCommon):
             0.0 if warning threshold is not supported or module is under initialization
             other float value if warning threshold is available
         """
-        if not self.get_presence():
-            return None
         try:
             self.is_sw_control()
         except:
@@ -1114,8 +1110,6 @@ class SFP(NvidiaSFPCommon):
             0.0 if critical threshold is not supported or module is under initialization
             other float value if critical threshold is available
         """
-        if not self.get_presence():
-            return None
         try:
             self.is_sw_control()
         except:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -483,6 +483,9 @@ class SFP(NvidiaSFPCommon):
         Returns:
             bool: True if device is present, False if not
         """
+        presence_sysfs = f'/sys/module/sx_core/asic0/module{self.sdk_index}/hw_present' if self.is_sw_control() else f'/sys/module/sx_core/asic0/module{self.sdk_index}/present'
+        if utils.read_int_from_file(presence_sysfs) != 1:
+            return False
         eeprom_raw = self._read_eeprom(0, 1, log_on_error=False)
         return eeprom_raw is not None
 
@@ -1061,6 +1064,8 @@ class SFP(NvidiaSFPCommon):
             0.0 if module temperature is not supported or module is under initialization
             other float value if module temperature is available
         """
+        if not self.get_presence():
+            return None
         try:
             if not self.is_sw_control():
                 temp_file = f'/sys/module/sx_core/asic0/module{self.sdk_index}/temperature/input'
@@ -1085,6 +1090,8 @@ class SFP(NvidiaSFPCommon):
             0.0 if warning threshold is not supported or module is under initialization
             other float value if warning threshold is available
         """
+        if not self.get_presence():
+            return None
         try:
             self.is_sw_control()
         except:
@@ -1107,6 +1114,8 @@ class SFP(NvidiaSFPCommon):
             0.0 if critical threshold is not supported or module is under initialization
             other float value if critical threshold is available
         """
+        if not self.get_presence():
+            return None
         try:
             self.is_sw_control()
         except:
@@ -1938,3 +1947,4 @@ class RJ45Port(NvidiaSFPCommon):
         """
         status = super().get_module_status()
         return SFP_STATUS_REMOVED if status == SFP_STATUS_UNKNOWN else status
+

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -435,6 +435,8 @@ class ModuleThermal(ThermalBase):
             A float number of current temperature in Celsius up to nearest thousandth
             of one degree Celsius, e.g. 30.125
         """
+        if not self.sfp.get_presence():
+            return None
         value = self.sfp.get_temperature()
         return value if (value != 0.0 and value is not None) else None
 
@@ -446,6 +448,8 @@ class ModuleThermal(ThermalBase):
             A float number, the high threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
+        if not self.sfp.get_presence():
+            return None
         value = self.sfp.get_temperature_warning_threshold()
         return value if (value != 0.0 and value is not None) else None
 
@@ -457,6 +461,8 @@ class ModuleThermal(ThermalBase):
             A float number, the high critical threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
+        if not self.sfp.get_presence():
+            return None
         value = self.sfp.get_temperature_critical_threshold()
         return value if (value != 0.0 and value is not None) else None
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -247,14 +247,22 @@ class TestSfp:
         assert page == '/tmp/1/data'
         assert page_offset is 0
 
+    @mock.patch('sonic_platform.utils.read_int_from_file')
     @mock.patch('sonic_platform.sfp.SFP._read_eeprom')
-    def test_sfp_get_presence(self, mock_read):
+    def test_sfp_get_presence(self, mock_read, mock_read_int):
         sfp = SFP(0)
+
+        mock_read_int.return_value = 1
         mock_read.return_value = None
         assert not sfp.get_presence()
-
         mock_read.return_value = 0
         assert sfp.get_presence()
+
+        mock_read_int.return_value = 0
+        mock_read.return_value = None
+        assert not sfp.get_presence()
+        mock_read.return_value = 0
+        assert not sfp.get_presence()
 
     @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_rj45_get_presence(self, mock_read_int):

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
@@ -159,12 +159,21 @@ class TestThermal:
         assert thermal.get_name() == rule['name'].format(start_index)
         assert thermal.get_position_in_parent() == 1
         assert thermal.is_replaceable() == False
+        sfp.get_presence = mock.MagicMock(return_value=True)
         sfp.get_temperature = mock.MagicMock(return_value=35.4)
         sfp.get_temperature_warning_threshold = mock.MagicMock(return_value=70)
         sfp.get_temperature_critical_threshold = mock.MagicMock(return_value=80)
         assert thermal.get_temperature() == 35.4
         assert thermal.get_high_threshold() == 70
         assert thermal.get_high_critical_threshold() == 80
+        sfp.get_presence = mock.MagicMock(return_value=False)
+        sfp.get_temperature = mock.MagicMock(return_value=35.4)
+        sfp.get_temperature_warning_threshold = mock.MagicMock(return_value=70)
+        sfp.get_temperature_critical_threshold = mock.MagicMock(return_value=80)
+        assert thermal.get_temperature() is None
+        assert thermal.get_high_threshold() is None
+        assert thermal.get_high_critical_threshold() is None
+        sfp.get_presence = mock.MagicMock(return_value=True)
         sfp.get_temperature = mock.MagicMock(return_value=0)
         sfp.get_temperature_warning_threshold = mock.MagicMock(return_value=0)
         sfp.get_temperature_critical_threshold = mock.MagicMock(return_value=None)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, when trying to read from the EEPROM of an unplugged module from thermalctld, we get the following error:
ERR kernel: [ 2446.261799] sxd_kernel: [error] Failed to get module page valid, err: -5
We need to ensure the EEPROM is not accessed if a module is not connected.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I updated the logic of get_presence() to rely on the present/hw_present sysfs values and called get_presence() from within the relevant methods in thermalctld.

#### How to verify it
Unplug a module and ensure the following error does not appear:
ERR kernel: [ 2446.261799] sxd_kernel: [error] Failed to get module page valid, err: -5

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

