### PR TITLE
[Mellanox] Add functionality to handle empty EEPROM files

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -553,6 +553,9 @@ class SFP(NvidiaSFPCommon):
                     else:
                         result += content
                     read_length = len(content)
+                    if read_length == 0:
+                        logger.log_error(f'SFP {self.sdk_index}: EEPROM page {page} is empty, no data retrieved')
+                        return None
                     num_bytes -= read_length
                     if num_bytes > 0:
                         page_size = f.seek(0, os.SEEK_END)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It was decided that a good way to simulate an I2C stuck scenario would be to have the files representing the module's EEPROM remain empty. When these files are empty, module initialization will not complete because the read_eeprom() function gets stuck in an infinite loop (```while num_bytes > 0:``` will never evaluate to False as the decrement operation ```num_bytes -= read_length``` has no effect). This happens because 0 bytes are always read from the EEPROM when it is empty. This PR addresses this issue.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I added a validation check to ensure that if an attempt to read from the EEPROM results in 0 bytes read, the _read_eeprom() function exits and returns None.

#### How to verify it
Simulate the empty EEPROM (can be done as described in the script below), update _get_eeprom_path() to redirect to the empty EEPROM location, config reload, and verify that not all ports are down.

```bash
cd /
mkdir -p path_to_empty_files_folder
cd path_to_empty_files_folder

for i in $(seq 1 300); do
    mkdir -p $i
    touch $i/data
done

mkdir -p 0/i2c-0x50
touch 0/i2c-0x50/data
mkdir -p 0/i2c-0x51
touch 0/i2c-0x51/data
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

