### PR TITLE
[Mellanox] SN5600 SerDes signal integrity update

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/media_settings.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/media_settings.json
@@ -14,34 +14,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -54,14 +54,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:100GAUI-1-S": {
@@ -76,34 +76,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -116,14 +116,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:200GAUI-2-S": {
@@ -138,34 +138,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -178,14 +178,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:200GAUI-2-L": {
@@ -200,34 +200,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -240,14 +240,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:200GAUI-4": {
@@ -324,34 +324,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -364,14 +364,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
 		    }
                 },
                 "speed:400GAUI-4-S": {
@@ -386,34 +386,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -426,14 +426,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:800G": {
@@ -448,34 +448,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -488,14 +488,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 }
             },
@@ -512,34 +512,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -552,14 +552,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:400GAUI-4-S": {
@@ -574,34 +574,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -614,14 +614,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:400GAUI-8": {
@@ -698,34 +698,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -738,14 +738,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:200GAUI-2-L": {
@@ -760,34 +760,34 @@
                         "lane7": "0x00000000"
                     },
                     "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
+                        "lane0": "0x00000003",
+                        "lane1": "0x00000003",
+                        "lane2": "0x00000003",
+                        "lane3": "0x00000003",
+                        "lane4": "0x00000003",
+                        "lane5": "0x00000003",
+                        "lane6": "0x00000003",
+                        "lane7": "0x00000003"
                     },
                     "pre1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec",
+                        "lane4": "0xffffffec",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xffffffec",
+                        "lane7": "0xffffffec"
                     },
                     "main": {
-                        "lane0": "0x0000002b",
-                        "lane1": "0x0000002b",
-                        "lane2": "0x0000002b",
-                        "lane3": "0x0000002b",
-                        "lane4": "0x0000002b",
-                        "lane5": "0x0000002b",
-                        "lane6": "0x0000002b",
-                        "lane7": "0x0000002b"
+                        "lane0": "0x00000028",
+                        "lane1": "0x00000028",
+                        "lane2": "0x00000028",
+                        "lane3": "0x00000028",
+                        "lane4": "0x00000028",
+                        "lane5": "0x00000028",
+                        "lane6": "0x00000028",
+                        "lane7": "0x00000028"
                     },
                     "post1": {
                         "lane0": "0x00000000",
@@ -800,14 +800,14 @@
                         "lane7": "0x00000000"
                     },
                     "idriver": {
-                        "lane0": "0x00000037",
-                        "lane1": "0x00000037",
-                        "lane2": "0x00000037",
-                        "lane3": "0x00000037",
-                        "lane4": "0x00000037",
-                        "lane5": "0x00000037",
-                        "lane6": "0x00000037",
-                        "lane7": "0x00000037"
+                        "lane0": "0x0000003f",
+                        "lane1": "0x0000003f",
+                        "lane2": "0x0000003f",
+                        "lane3": "0x0000003f",
+                        "lane4": "0x0000003f",
+                        "lane5": "0x0000003f",
+                        "lane6": "0x0000003f",
+                        "lane7": "0x0000003f"
                     }
                 },
                 "speed:200GAUI-4": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To optimize SerDes SI values for SN5600.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
On Mellanox platform only, I updated media_settings.json for SN5600

#### How to verify it
Manual testing.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

