### PR TITLE
[Mellanox] Retry mechanism to EEPROM accesses

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -512,9 +512,10 @@ class SFP(NvidiaSFPCommon):
         for attempt in range(MAX_ATTEMPTS):
             result, err = self._read_eeprom(offset, num_bytes, log_on_error)
             if result is not None:
-                logger.log_debug(
-                    f"EEPROM read success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
-                    f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes})")
+                if attempt > 0:
+                    logger.log_notice(
+                        f"EEPROM read success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
+                        f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes})")
                 return result
 
             log_func = (logger.log_error if attempt + 1 > EEPROM_RETRY_ERR_THRESHOLD else logger.log_debug)
@@ -630,9 +631,10 @@ class SFP(NvidiaSFPCommon):
         for attempt in range(MAX_ATTEMPTS):
             ret, err = self._write_eeprom(offset, num_bytes, write_buffer)
             if ret:
-                logger.log_debug(
-                    f"EEPROM write success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
-                    f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}")
+                if attempt > 0:
+                    logger.log_notice(
+                        f"EEPROM write success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
+                        f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}")
                 return True
 
             log_func = (logger.log_error if attempt + 1 > EEPROM_RETRY_ERR_THRESHOLD else logger.log_debug)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -224,6 +224,9 @@ SFF_POWER_CLASS_8_OFFSET = 107
 CMIS_MCI_EEPROM_OFFSET = 2
 CMIS_MCI_MASK = 0b00001100
 
+MAX_ATTEMPTS = 50
+RETRY_SLEEP_SEC = 0.1
+
 STATE_DOWN = 'Down'                             # Initial state
 STATE_INIT = 'Initializing'                     # Module starts initializing, check module present, also power on the module if need
 STATE_RESETTING = 'Resetting'                   # Module is resetting the firmware
@@ -476,23 +479,15 @@ class SFP(NvidiaSFPCommon):
         Returns:
             bool: True if device is present, False if not
         """
-
-        try:
-            presence_file =  'hw_present' if self.is_sw_control() else 'present'
-            if utils.read_int_from_file(f'/sys/module/sx_core/asic0/module{self.sdk_index}/{presence_file}', log_func=None) != 1:
-                return False
-            eeprom_raw = self._read_eeprom(0, 1, log_on_error=False)
-            return eeprom_raw is not None
-        except Exception as e:
-            logger.log_warning(f'Failed to check presence of SFP {self.sdk_index}: {e}')
-            return False
-
+        presence_sysfs = f'/sys/module/sx_core/asic0/module{self.sdk_index}/hw_present' if self.is_sw_control() else f'/sys/module/sx_core/asic0/module{self.sdk_index}/present'
+        return utils.read_int_from_file(presence_sysfs) == 1
+    
     @classmethod
     def wait_sfp_eeprom_ready(cls, sfp_list, wait_time):
         not_ready_list = sfp_list
         
         while wait_time > 0:
-            not_ready_list = [s for s in not_ready_list if s.state == STATE_FW_CONTROL and s._read_eeprom(0, 2,False) is None]
+            not_ready_list = [s for s in not_ready_list if s.state == STATE_FW_CONTROL and s._read_eeprom(0, 1,False) is None]
             if not_ready_list:
                 time.sleep(0.1)
                 wait_time -= 0.1
@@ -515,17 +510,36 @@ class SFP(NvidiaSFPCommon):
         return self._read_eeprom(0, 1, log_on_error=False) is not None
 
     # read eeprom specfic bytes beginning from offset with size as num_bytes
-    def read_eeprom(self, offset, num_bytes):
+    def read_eeprom(self, offset, num_bytes, log_on_error=True):
         """
-        Read eeprom specfic bytes beginning from a random offset with size as num_bytes
+        Read eeprom specfic bytes beginning from a random offset with size as num_bytes. Tries up to 50 times total on every 0.1s.
         Returns:
             bytearray, if raw sequence of bytes are read correctly from the offset of size num_bytes
             None, if the read_eeprom fails
         """
-        return self._read_eeprom(offset, num_bytes)
+        for attempt in range(MAX_ATTEMPTS):
+            result = self._read_eeprom(offset, num_bytes, log_on_error)
+            if result is not None:
+                logger.log_notice(
+                    f"EEPROM read success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
+                    f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes})")
+                return result
+            if attempt < MAX_ATTEMPTS - 1:  # only sleep if another retry will happen
+                logger.log_notice(
+                    f"EEPROM read attempt {attempt + 1}/{MAX_ATTEMPTS} failed "
+                    f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes}). "
+                    f"Retrying in {RETRY_SLEEP_SEC:.1f}s...")
+                time.sleep(RETRY_SLEEP_SEC)
+
+        if log_on_error:
+            logger.log_error(
+                f"EEPROM read failed after {MAX_ATTEMPTS} attempts "
+                f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes})")
+        return None
 
     def _read_eeprom(self, offset, num_bytes, log_on_error=True):
-        """Read eeprom specfic bytes beginning from a random offset with size as num_bytes
+        """
+        Single-attempt read: Read eeprom specfic bytes beginning from a random offset with size as num_bytes
 
         Args:
             offset (int): read offset
@@ -563,12 +577,18 @@ class SFP(NvidiaSFPCommon):
                             num_bytes = 0
                     if ctypes.get_errno() != 0:
                         raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
-                    logger.log_debug(f'read EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, '\
-                        f'size={read_length}, data={content}')
+
+                    logger.log_debug(
+                        f"read EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, "
+                        f"size={read_length}, data={content}"
+                    )
+
             except (OSError, IOError) as e:
                 if log_on_error:
-                    logger.log_warning(f'Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, '\
-                        f'size={num_bytes}, offset={offset}, error = {e}')
+                    logger.log_warning(
+                        f"Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, "
+                        f"size={num_bytes}, offset={offset}, error = {e}"
+                    )
                 return None
 
         return bytearray(result)
@@ -577,16 +597,43 @@ class SFP(NvidiaSFPCommon):
     def write_eeprom(self, offset, num_bytes, write_buffer):
         """
         write eeprom specfic bytes beginning from a random offset with size as num_bytes
+        and write_buffer as the required bytes. Tries up to 50 times total on every 0.1s.
+        Returns:
+            Boolean, true if the write succeeded and false if it did not succeed.
+        """
+        if num_bytes != len(write_buffer):
+            logger.log_error("Error mismatch between buffer length and number of bytes to be written")
+            return False
+
+        for attempt in range(MAX_ATTEMPTS):
+            ret = self._write_eeprom(offset, num_bytes, write_buffer)
+            if ret:
+                logger.log_notice(
+                    f"EEPROM write success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
+                    f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}")
+                return True
+            logger.log_notice(
+                f"EEPROM write attempt {attempt + 1}/{MAX_ATTEMPTS} failed "
+                f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}. "
+                f"Retrying in {RETRY_SLEEP_SEC:.1f}s..."
+            )
+            time.sleep(RETRY_SLEEP_SEC)
+
+        logger.log_error(
+            f"EEPROM write failed after {MAX_ATTEMPTS} attempts "
+            f"for sfp={getattr(self, 'sdk_index', 'N/A')}, offset={offset}, size={num_bytes}"
+        )
+        return False
+
+    def _write_eeprom(self, offset, num_bytes, write_buffer):
+        """
+        Single-attempt write: write eeprom specfic bytes beginning from a random offset with size as num_bytes
         and write_buffer as the required bytes
         Returns:
             Boolean, true if the write succeeded and false if it did not succeed.
         Example:
             mlxreg -d /dev/mst/mt52100_pciconf0 --reg_name MCIA --indexes slot_index=0,module=1,device_address=154,page_number=5,i2c_device_address=0x50,size=1,bank_number=0 --set dword[0]=0x01000000 -y
         """
-        if num_bytes != len(write_buffer):
-            logger.log_error("Error mismatch between buffer length and number of bytes to be written")
-            return False
-
         while num_bytes > 0:
             page_num, page, page_offset = self._get_page_and_page_offset(offset)
             if not page:
@@ -611,12 +658,13 @@ class SFP(NvidiaSFPCommon):
                     num_bytes -= ret
                     if ctypes.get_errno() != 0:
                         raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
-                    logger.log_debug(f'write EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, '\
-                        f'size={ret}, left={num_bytes}, data={written_buffer}')
+                    logger.log_debug('write EEPROM sfp={}, page={}, page_offset={}, size={}, left={}, data={}'.format(self.sdk_index, page, page_offset, ret, num_bytes, written_buffer))
             except (OSError, IOError) as e:
                 data = ''.join('{:02x}'.format(x) for x in write_buffer)
-                logger.log_error(f'Failed to write EEPROM data sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, size={num_bytes}, '\
-                    f'offset={offset}, data = {data}, error = {e}')
+                logger.log_error(
+                    f"Failed to write EEPROM: sfp={self.sdk_index}, page={page}, page_offset={page_offset}, "
+                    f"size={num_bytes}, offset={offset}, data={data}, error={e}"
+                )
                 return False
         return True
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -29,6 +29,7 @@ try:
     import os
     import threading
     import time
+    import errno
     from sonic_py_common.logger import Logger
     from sonic_py_common import multi_asic
     from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
@@ -226,6 +227,7 @@ CMIS_MCI_MASK = 0b00001100
 
 MAX_ATTEMPTS = 50
 RETRY_SLEEP_SEC = 0.1
+EEPROM_RETRY_ERR_THRESHOLD = 10
 
 STATE_DOWN = 'Down'                             # Initial state
 STATE_INIT = 'Initializing'                     # Module starts initializing, check module present, also power on the module if need
@@ -499,24 +501,44 @@ class SFP(NvidiaSFPCommon):
 
     def read_eeprom(self, offset, num_bytes, log_on_error=True):
         """
-        Read eeprom specific bytes beginning from a random offset with size as num_bytes. Tries up to 50 times total on every 0.1s.
+        Read eeprom specific bytes beginning from a random offset with size as num_bytes.
+        Retries up to 50 times in total (every 0.1s), but only if previous attempts failed due to I2C errors
+        (errno.EIO, typically reported as -5 from the kernel).
+
         Returns:
-            bytearray, if raw sequence of bytes are read correctly from the offset of size num_bytes
-            None, if the read_eeprom fails
+            bytearray: If the data was successfully read.
+            None: If all attempts failed (whether due to I2C errors after max retries, or due to other errors without retry).
         """
         for attempt in range(MAX_ATTEMPTS):
-            result = self._read_eeprom(offset, num_bytes, log_on_error)
+            result, err = self._read_eeprom(offset, num_bytes, log_on_error)
             if result is not None:
-                logger.log_notice(
+                logger.log_debug(
                     f"EEPROM read success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
                     f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes})")
                 return result
-            if attempt < MAX_ATTEMPTS - 1:  # only sleep if another retry will happen
-                logger.log_notice(
-                    f"EEPROM read attempt {attempt + 1}/{MAX_ATTEMPTS} failed "
+
+            log_func = (logger.log_error if attempt + 1 > EEPROM_RETRY_ERR_THRESHOLD else logger.log_debug)
+
+            # Retry only on EIO (-5)
+            if err == errno.EIO and attempt < MAX_ATTEMPTS - 1:
+                log_func(
+                    f"EEPROM read attempt {attempt + 1}/{MAX_ATTEMPTS} failed with I2C error "
                     f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes}). "
                     f"Retrying in {RETRY_SLEEP_SEC:.1f}s...")
                 time.sleep(RETRY_SLEEP_SEC)
+                continue
+
+            # Non-I2C-error or last attempt → stop retrying
+            if err is not None:
+                log_func(
+                    f"EEPROM read failed (errno={err}, {os.strerror(err)}) "
+                    f"after attempt {attempt + 1}/{MAX_ATTEMPTS} "
+                    f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes})")
+            else:
+                log_func(
+                    f"EEPROM read failed after attempt {attempt + 1}/{MAX_ATTEMPTS} "
+                    f"(sfp={self.sdk_index}, offset={offset}, size={num_bytes})")
+            return None
 
         if log_on_error:
             logger.log_error(
@@ -534,26 +556,29 @@ class SFP(NvidiaSFPCommon):
             log_on_error (bool, optional): whether log error when exception occurs. Defaults to True.
 
         Returns:
-            bytearray: the content of EEPROM
+            (bytearray, None): On success, returns the data read and None for errno.
+            (None, errno): On failure due to a specific OS error, returns None and the errno value.
+            (None, None): On failure without an associated errno (e.g., empty page or invalid page).
         """
         result = bytearray(0)
         while num_bytes > 0:
             _, page, page_offset = self._get_page_and_page_offset(offset)
             if not page:
-                return None
+                return None, None
 
             try:
                 with open(page, mode='rb', buffering=0) as f:
                     f.seek(page_offset)
                     content = f.read(num_bytes)
+                    read_length = len(content)
+                    if read_length == 0:
+                        logger.log_error(f'SFP {self.sdk_index}: EEPROM page {page} is empty, no data retrieved')
+                        return None, None
+
                     if not result:
                         result = content
                     else:
                         result += content
-                    read_length = len(content)
-                    if read_length == 0:
-                        logger.log_error(f'SFP {self.sdk_index}: EEPROM page {page} is empty, no data retrieved')
-                        return None
                     num_bytes -= read_length
                     if num_bytes > 0:
                         page_size = f.seek(0, os.SEEK_END)
@@ -562,48 +587,76 @@ class SFP(NvidiaSFPCommon):
                         else:
                             # Indicate read finished
                             num_bytes = 0
+
                     if ctypes.get_errno() != 0:
-                        raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
+                        return None, ctypes.get_errno()
 
                     logger.log_debug(
                         f"read EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, "
                         f"size={read_length}, data={content}"
                     )
 
-            except (OSError, IOError) as e:
+            except OSError as e:
                 if log_on_error:
-                    logger.log_warning(
-                        f"Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, "
-                        f"size={num_bytes}, offset={offset}, error = {e}"
-                    )
-                return None
+                    if e.errno is not None:
+                        logger.log_warning(
+                            f"Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, "
+                            f"size={num_bytes}, offset={offset}, error={e} "
+                            f"(errno={e.errno}, {os.strerror(e.errno)})"
+                        )
+                    else:
+                        logger.log_warning(
+                            f"Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, "
+                            f"size={num_bytes}, offset={offset}, error={e}"
+                        )
+                return None, e.errno
 
-        return bytearray(result)
+        return bytearray(result), None
+
 
     def write_eeprom(self, offset, num_bytes, write_buffer):
         """
-        write eeprom specific bytes beginning from a random offset with size as num_bytes
-        and write_buffer as the required bytes. Tries up to 50 times total on every 0.1s.
+        Write EEPROM specific bytes beginning from a random offset with size as num_bytes
+        and write_buffer as the required bytes. Retries up to 50 times (every 0.1s) only if
+        previous attempts failed due to I2C errors (errno.EIO).
+
         Returns:
-            Boolean, true if the write succeeded and false if it did not succeed.
+            Boolean, True if the write succeeded, False if it did not succeed.
         """
         if num_bytes != len(write_buffer):
             logger.log_error("Error mismatch between buffer length and number of bytes to be written")
             return False
 
         for attempt in range(MAX_ATTEMPTS):
-            ret = self._write_eeprom(offset, num_bytes, write_buffer)
+            ret, err = self._write_eeprom(offset, num_bytes, write_buffer)
             if ret:
-                logger.log_notice(
+                logger.log_debug(
                     f"EEPROM write success after attempt {attempt + 1}/{MAX_ATTEMPTS} "
                     f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}")
                 return True
-            logger.log_notice(
-                f"EEPROM write attempt {attempt + 1}/{MAX_ATTEMPTS} failed "
-                f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}. "
-                f"Retrying in {RETRY_SLEEP_SEC:.1f}s..."
-            )
-            time.sleep(RETRY_SLEEP_SEC)
+
+            log_func = (logger.log_error if attempt + 1 > EEPROM_RETRY_ERR_THRESHOLD else logger.log_debug)
+
+            # Retry only on EIO (-5)
+            if err == errno.EIO and attempt < MAX_ATTEMPTS - 1:
+                log_func(
+                    f"EEPROM write attempt {attempt + 1}/{MAX_ATTEMPTS} failed with I2C error "
+                    f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}. "
+                    f"Retrying in {RETRY_SLEEP_SEC:.1f}s...")
+                time.sleep(RETRY_SLEEP_SEC)
+                continue
+
+            # Non-I2C-error or last attempt → stop retrying
+            if err is not None:
+                log_func(
+                    f"EEPROM write failed (errno={err}, {os.strerror(err)}) "
+                    f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes} "
+                    f"after attempt {attempt + 1}/{MAX_ATTEMPTS}")
+            else:
+                log_func(
+                    f"EEPROM write failed for sfp={self.sdk_index}, offset={offset}, size={num_bytes} "
+                    f"after attempt {attempt + 1}/{MAX_ATTEMPTS}")
+            return False
 
         logger.log_error(
             f"EEPROM write failed after {MAX_ATTEMPTS} attempts "
@@ -616,19 +669,23 @@ class SFP(NvidiaSFPCommon):
         Single-attempt write: write eeprom specific bytes beginning from a random offset with size as num_bytes
         and write_buffer as the required bytes
         Returns:
-            Boolean, true if the write succeeded and false if it did not succeed.
+            (True, None): On success.
+            (False, errno): On failure with a specific OS error.
+            (False, None): On failure without an associated errno (e.g., unexpected short write).
+
         Example:
             mlxreg -d /dev/mst/mt52100_pciconf0 --reg_name MCIA --indexes slot_index=0,module=1,device_address=154,page_number=5,i2c_device_address=0x50,size=1,bank_number=0 --set dword[0]=0x01000000 -y
         """
         while num_bytes > 0:
             page_num, page, page_offset = self._get_page_and_page_offset(offset)
             if not page:
-                return False
+                return False, None
 
             try:
                 if self._is_write_protected(page_num, page_offset, num_bytes):
                     # write limited eeprom is not supported
-                    raise IOError('write limited bytes')
+                    raise OSError(errno.EPERM, 'write limited bytes')
+
                 with open(page, mode='r+b', buffering=0) as f:
                     f.seek(page_offset)
                     ret = f.write(write_buffer[0:num_bytes])
@@ -640,19 +697,29 @@ class SFP(NvidiaSFPCommon):
                             write_buffer = write_buffer[ret:num_bytes]
                             offset += ret
                         else:
-                            raise IOError(f'write return code = {ret}')
+                            logger.log_error(
+                                f"Unexpected short write (ret={ret} < {num_bytes}) "
+                                f"for sfp={self.sdk_index}, page={page}, page_offset={page_offset}, offset={offset}"
+                            )
+                            return False, None
                     num_bytes -= ret
                     if ctypes.get_errno() != 0:
-                        raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
-                    logger.log_debug('write EEPROM sfp={}, page={}, page_offset={}, size={}, left={}, data={}'.format(self.sdk_index, page, page_offset, ret, num_bytes, written_buffer))
-            except (OSError, IOError) as e:
+                        return False, ctypes.get_errno()
+
+                    logger.log_debug(
+                        'write EEPROM sfp={}, page={}, page_offset={}, size={}, left={}, data={}'
+                        .format(self.sdk_index, page, page_offset, ret, num_bytes, written_buffer)
+                    )
+
+            except OSError as e:
                 data = ''.join('{:02x}'.format(x) for x in write_buffer)
                 logger.log_error(
                     f"Failed to write EEPROM: sfp={self.sdk_index}, page={page}, page_offset={page_offset}, "
                     f"size={num_bytes}, offset={offset}, data={data}, error={e}"
                 )
-                return False
-        return True
+                return False, e.errno
+
+        return True, None
 
     def get_lpmode(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -497,22 +497,9 @@ class SFP(NvidiaSFPCommon):
         for s in not_ready_list:
             logger.log_error(f'SFP {s.sdk_index} eeprom is not ready')
 
-    def check_eeprom_ready_if_present(self):
-        """
-        Check if the eeprom is ready for a present SFP
-
-        Returns:
-            bool: False if the SFP is present and the eeprom is not ready, True otherwise
-        """
-        presence_file =  'hw_present' if self.is_sw_control() else 'present'
-        if utils.read_int_from_file(f'/sys/module/sx_core/asic0/module{self.sdk_index}/{presence_file}', log_func=None) != 1:
-            return True
-        return self._read_eeprom(0, 1, log_on_error=False) is not None
-
-    # read eeprom specfic bytes beginning from offset with size as num_bytes
     def read_eeprom(self, offset, num_bytes, log_on_error=True):
         """
-        Read eeprom specfic bytes beginning from a random offset with size as num_bytes. Tries up to 50 times total on every 0.1s.
+        Read eeprom specific bytes beginning from a random offset with size as num_bytes. Tries up to 50 times total on every 0.1s.
         Returns:
             bytearray, if raw sequence of bytes are read correctly from the offset of size num_bytes
             None, if the read_eeprom fails
@@ -539,7 +526,7 @@ class SFP(NvidiaSFPCommon):
 
     def _read_eeprom(self, offset, num_bytes, log_on_error=True):
         """
-        Single-attempt read: Read eeprom specfic bytes beginning from a random offset with size as num_bytes
+        Single-attempt read: Read eeprom specific bytes beginning from a random offset with size as num_bytes
 
         Args:
             offset (int): read offset
@@ -593,10 +580,9 @@ class SFP(NvidiaSFPCommon):
 
         return bytearray(result)
 
-    # write eeprom specfic bytes beginning from offset with size as num_bytes
     def write_eeprom(self, offset, num_bytes, write_buffer):
         """
-        write eeprom specfic bytes beginning from a random offset with size as num_bytes
+        write eeprom specific bytes beginning from a random offset with size as num_bytes
         and write_buffer as the required bytes. Tries up to 50 times total on every 0.1s.
         Returns:
             Boolean, true if the write succeeded and false if it did not succeed.
@@ -621,13 +607,13 @@ class SFP(NvidiaSFPCommon):
 
         logger.log_error(
             f"EEPROM write failed after {MAX_ATTEMPTS} attempts "
-            f"for sfp={getattr(self, 'sdk_index', 'N/A')}, offset={offset}, size={num_bytes}"
+            f"for sfp={self.sdk_index}, offset={offset}, size={num_bytes}"
         )
         return False
 
     def _write_eeprom(self, offset, num_bytes, write_buffer):
         """
-        Single-attempt write: write eeprom specfic bytes beginning from a random offset with size as num_bytes
+        Single-attempt write: write eeprom specific bytes beginning from a random offset with size as num_bytes
         and write_buffer as the required bytes
         Returns:
             Boolean, true if the write succeeded and false if it did not succeed.

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -225,9 +225,9 @@ SFF_POWER_CLASS_8_OFFSET = 107
 CMIS_MCI_EEPROM_OFFSET = 2
 CMIS_MCI_MASK = 0b00001100
 
-MAX_ATTEMPTS = 50
+MAX_ATTEMPTS = 5
 RETRY_SLEEP_SEC = 0.1
-EEPROM_RETRY_ERR_THRESHOLD = 10
+EEPROM_RETRY_ERR_THRESHOLD = 2
 
 STATE_DOWN = 'Down'                             # Initial state
 STATE_INIT = 'Initializing'                     # Module starts initializing, check module present, also power on the module if need

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -245,7 +245,7 @@ class TestSfp:
         assert page_offset is 0
 
     @mock.patch('sonic_platform.utils.read_int_from_file')
-    @mock.patch('sonic_platform.sfp.SFP._read_eeprom')
+    @mock.patch('sonic_platform.sfp.SFP.read_eeprom')
     def test_sfp_get_presence(self, mock_read, mock_read_int):
         sfp = SFP(0)
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -245,20 +245,13 @@ class TestSfp:
         assert page_offset is 0
 
     @mock.patch('sonic_platform.utils.read_int_from_file')
-    @mock.patch('sonic_platform.sfp.SFP.read_eeprom')
-    def test_sfp_get_presence(self, mock_read, mock_read_int):
+    def test_sfp_get_presence(self, mock_read_int):
         sfp = SFP(0)
 
         mock_read_int.return_value = 1
-        mock_read.return_value = None
-        assert not sfp.get_presence()
-        mock_read.return_value = 0
         assert sfp.get_presence()
 
         mock_read_int.return_value = 0
-        mock_read.return_value = None
-        assert not sfp.get_presence()
-        mock_read.return_value = 0
         assert not sfp.get_presence()
 
     @mock.patch('sonic_platform.utils.read_int_from_file')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, if an EEPROM read or write attempt fails, it is not retried. To make EEPROM access more robust and reliable, this PR introduces a retry mechanism for both read and write operations.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added retry attempts for EEPROM read/write operations when the initial attempt fails, up to a total of 50 attempts with 100 ms intervals.
- Introduced corresponding NOTICE logs to indicate retry attempts and successes.

#### How to verify it
Manual testing.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

